### PR TITLE
Add Geyser UUID Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 compileJava.options.encoding 'UTF-8'
 
 group 'me.fredthedoggy'
-version '1.0.3'
+version '1.0.4'
 
 shadowJar {
     relocate 'org.bstats', 'me.fredthedoggy.restpapi'

--- a/src/main/java/me/fredthedoggy/restpapi/SparkWrapper.java
+++ b/src/main/java/me/fredthedoggy/restpapi/SparkWrapper.java
@@ -12,7 +12,7 @@ import static spark.Service.ignite;
 class SparkWrapper {
     Service http;
 
-    void create(int port, List < String > tokens) {
+    void create(int port, List<String> tokens) {
         http = ignite().port(port);
         http.get("/:uuid/:placeholder", (request, response) -> {
 

--- a/src/main/java/me/fredthedoggy/restpapi/SparkWrapper.java
+++ b/src/main/java/me/fredthedoggy/restpapi/SparkWrapper.java
@@ -12,10 +12,9 @@ import static spark.Service.ignite;
 class SparkWrapper {
     Service http;
 
-    void create(int port, List<String> tokens) {
+    void create(int port, List < String > tokens) {
         http = ignite().port(port);
         http.get("/:uuid/:placeholder", (request, response) -> {
-
 
             if (request.headers("token") == null) {
                 response.type("application/json");
@@ -27,39 +26,38 @@ class SparkWrapper {
                 return "{\"status\":\"401\",\"message\":\"Unauthorized\"}";
             } else {
                 response.type("application/json");
-                if (request.params(":uuid").matches("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")) {
+                UUID specifiedUUID;
+                try {
+                    specifiedUUID = UUID.fromString(request.params(":uuid"));
+                }
+                catch(Exception e) {
+                    response.type("application/json");
+                    response.status(400);
+                    return "{\"status\":\"400\",\"message\":\"Invalid UUID\"}";
+                }
+                if (Bukkit.getOfflinePlayer(specifiedUUID).hasPlayedBefore()) {
 
-                    if (Bukkit.getOfflinePlayer(UUID.fromString(request.params(":uuid"))).hasPlayedBefore()) {
+                    response.type("application/json");
+                    response.status(200);
+
+                    String Placeholder = "{\"status\":\"200\",\"message\":\"" + PlaceholderAPI.setPlaceholders(Bukkit.getOfflinePlayer(UUID.fromString(request.params(":uuid"))), "%" + request.params(":placeholder") + "%") + "\"}";
+
+                    if (Placeholder.equals("%" + request.params(":placeholder") + "%")) {
 
                         response.type("application/json");
-                        response.status(200);
+                        response.status(406);
+                        return "{\"status\":\"406\",\"message\":\"Invalid Placeholder\"}";
 
-                        String Placeholder = "{\"status\":\"200\",\"message\":\"" + PlaceholderAPI.setPlaceholders(Bukkit.getOfflinePlayer(UUID.fromString(request.params(":uuid"))), "%" + request.params(":placeholder") + "%") + "\"}";
-
-                        if (Placeholder.equals("%" + request.params(":placeholder") + "%")) {
-
-                            response.type("application/json");
-                            response.status(406);
-                            return "{\"status\":\"406\",\"message\":\"Invalid Placeholder\"}";
-
-                        } else {
-
-                            return Placeholder;
-
-                        }
                     } else {
 
-                        response.type("application/json");
-                        response.status(400);
-                        return "{\"status\":\"400\",\"message\":\"Player Has Not Played Before\"}";
+                        return Placeholder;
 
                     }
-
                 } else {
 
                     response.type("application/json");
-                    response.status(404);
-                    return "{\"status\":\"404\",\"message\":\"Invalid UUID\"}";
+                    response.status(400);
+                    return "{\"status\":\"400\",\"message\":\"Player Has Not Played Before\"}";
 
                 }
             }


### PR DESCRIPTION
This PR right here ads Geyser UUID support and removes the poor regex solution. Aka, if the UUID is on the server and if it's a basic valid UUID, mind your business! 

I have tested these changes on my test server and KNOW they will work, so easy PR. 

I also bumped the version number because this is a minor change that breaks nothing and doesn't change anything much besides allowing UUIDs like 00000000-0000-0000-0009-01f66f7acd9f. 